### PR TITLE
Add Food Manager feature

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,15 @@ class Config:
         for staffer in staffer_list:
             staffer = staffer.strip()
             self.staffer_list.append(staffer)
+            
+        managerfile = open('food_managers.cfg', 'r')
+        managers = managerfile.read()
+        managerfile.close()
+        manager_list = managers.split(',')
+        self.food_managers = list()
+        for manager in manager_list:
+            manager = manager.strip()
+            self.food_managers.append(manager)
         
         deptfile = open('exempt_depts.cfg', 'r')
         depts = deptfile.read()
@@ -73,6 +82,7 @@ class Config:
         self.admin_list = ''
         self.staffer_list = ''
         self.exempt_depts = ''
+        self.food_managers = ''
         self.load_user_lists()
         
         self.api_endpoint = cdata['api_endpoint']
@@ -98,7 +108,7 @@ class Config:
         else:
             return False
         
-    def save(self, admin_list, staffer_list, exempt_depts):
+    def save(self, admin_list, staffer_list, exempt_depts, manager_list):
         cdata = {
             'api_endpoint': self.api_endpoint,
             'database_location': self.database_location,
@@ -127,6 +137,10 @@ class Config:
         deptfile = open('exempt_depts.cfg', 'w')
         deptfile.write(exempt_depts)
         deptfile.close()
+        
+        managerfile = open('food_managers.cfg', 'w')
+        managerfile.write(manager_list)
+        managerfile.close()
         
         self.load_user_lists()
         return

--- a/decorators.py
+++ b/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 import cherrypy
 
 from shared_functions import HTTPRedirect, is_admin, is_ss_staffer, is_dh
-
+from config import cfg
 
 def restricted(func):
     """
@@ -75,6 +75,7 @@ def ss_staffer(func):
 def dh_or_admin(func):
     """
     Requires user to be logged in and either a Department Head or an Admin.
+    Also now 'food manager' which is a non-DH person assigned to handle order related things
     Department Head status is determined at login by checking their account in Uber/Reggie
     """
     @wraps(func)
@@ -87,7 +88,7 @@ def dh_or_admin(func):
         allowed = False
         if cherrypy.session['is_dh'] or cherrypy.session['is_admin']:
             allowed = True
-        
+           
         if not allowed:
             raise HTTPRedirect('staffer_meal_list?message=You are not DH or admin, your id: ' + staff_id)
         
@@ -98,7 +99,7 @@ def dh_or_admin(func):
 
 def dh_or_staffer(func):
     """
-    Requires user to be logged in and either a Department Head or an Admin.
+    Requires user to be logged in and either a SS Staffer or Department Head or an Admin.
     Department Head status is determined at login by checking their account in Uber/Reggie
     """
     @wraps(func)

--- a/devconfig.json
+++ b/devconfig.json
@@ -1,5 +1,5 @@
 {
-  "api_endpoint": "https://onsite.reggie.magfest.org/jsonrpc/",
+  "api_endpoint": "https://staging-super.reggie.magfest.org/jsonrpc/",
   "database_location": "sqlite:///livedb.db",
   "local_print": true,
   "remote_print": false,

--- a/templates/base.html
+++ b/templates/base.html
@@ -98,7 +98,7 @@
             <div id="floating_logo">
                 <img src={{ c.EVENT_URL_ROOT }}/static/theme/bg-logo.png/>
                 <a href="https://bit.ly/StaffSuite2020" target="_blank">Staff Suite Info & Allergies</a>
-                <div style="text-align:center;"><h1>{{ c.EVENT_NAME }} Staff Suite v 0.8.7</h1></div>
+                <div style="text-align:center;"><h1>{{ c.EVENT_NAME }} Staff Suite v 0.9.0</h1></div>
             </div>
     {% endblock %}
     <div id="mainContainer" class="container-fluid">

--- a/templates/dept_order.html
+++ b/templates/dept_order.html
@@ -24,6 +24,18 @@
     <button style="width:3.25in;" class="btn btn-lg btn-primary btn-block" type="submit">Update Department's Contact Info</button>
   </form>
   <a style="width:5in;" class="btn btn-lg btn-primary btn-block" href="dept_contact?dept_id={{ dept_order.dept_id }}&original_location=dept_order%3Fmeal_id%3D{{ dept_order.meal_id }}%26dept_id%3D{{ dept_order.dept_id }}">Edit default contact info for {{ dept.name }}</a>
+  {% if not session.is_food_manager %}
+  <form>
+    <input type="hidden" name="dept_id" value="{{ dept_order.dept_id }}"/>
+    <input type="hidden" name="meal_id" value="{{ dept_order.meal_id }}"/>
+    <br/>
+    -----------------------------<br/>
+    <label>Badge Number</label>
+    <input type="text" name="food_manager">
+    <button style="width:2in;" class="btn btn-lg btn-primary btn-block" type="submit">Add Food Manager</button>
+    <br/>-----------------------------
+  </form>
+  {% endif %}
   {% if not dept_order.started %}
     <br/>
     -----------------------------<br/>


### PR DESCRIPTION
A food manager is a non-dh person who is assigned to handle orders for other people.
They have the same access as a DH but have to be manually added to a list of food managers by an existing DH or Admin.
The box to add them is on the Dept Orders screen after you have selected a specific department,
for lack of a better place.