### PR TITLE
Fix silly bug in Slack bot

### DIFF
--- a/slack_bot.py
+++ b/slack_bot.py
@@ -14,7 +14,7 @@ def send_message(channel, message):
 
     channel_list = channel.split(',')
     for chan in channel_list:
-        chan.strip()
+        chan = chan.strip()
         if chan[0] == '@':
             open_channel = {'token': cfg.slack_authkey,
                             'users': chan}


### PR DESCRIPTION
Turns out, in Python you can't just do string.strip()
you have to do string = string.strip()
The result of this bug was it would nearly always send to first target, but later ones would fail
due to leading space character confusing the API