### PR TITLE
Allow system to use badge numbers instead of Uber public ID, minor bugfix

### DIFF
--- a/shared_functions.py
+++ b/shared_functions.py
@@ -802,9 +802,10 @@ def is_dh(staff_id):
     # queries Uber/Reggie to find out if attendee is marked as a DH
     REQUEST_HEADERS = {'X-Auth-Token': cfg.uber_authkey}
     request_data = {'method': 'attendee.search',
-                    'params': [staff_id]}
+                    'params': [str(staff_id)]}
     request = requests.post(url=cfg.api_endpoint, json=request_data, headers=REQUEST_HEADERS)
     response = json.loads(request.text)
+
     return response['result'][0]['is_dept_head']
 
 

--- a/templates/ssf_orders.html
+++ b/templates/ssf_orders.html
@@ -5,7 +5,7 @@
 
 <div class="container">
   <h2>{{ message }} <br/></h2>
-  <a class="btn btn-lg btn-primary " href="ssf_dept_list?meal_id={{ meal.id }}&meal_name=meal.meal_name">Back to Department List</a> <br/>
+  <a class="btn btn-lg btn-primary " href="ssf_dept_list?meal_id={{ meal.id }}&meal_name={{ meal.meal_name }}">Back to Department List</a> <br/>
   {% if dept_order.started %}
   <h3>Orders locked!</h3><a class="btn btn-lg btn-primary " href="ssf_lock_order?meal_id={{ meal.id }}&dept_id={{ dept_id }}&unlock_order=True"{% if dept_order.completed %} disabled{% endif %}>Un-Lock orders for department</a> <br/>
   {% else %}

--- a/webcode.py
+++ b/webcode.py
@@ -1418,9 +1418,6 @@ class Root:
             # locks all remaining orders for dept and meal then checks if any remaining orders for meal
             # if no remaining orders marks them complete
             for dept in orderless_depts:
-                print('-------------------------dept object-----------------')
-                print(str(dept[0]) + '---' + str(dept[1]) + '---' + str(dept[2]))
-                print('-------------------------------------------------')
                 self.ssf_lock_order(meal_id, dept[2], no_redirect=True)
             for dept in orderless_depts:
                 order_count = session.query(Order).filter_by(department_id=dept[2], meal_id=meal_id).count()

--- a/webcode.py
+++ b/webcode.py
@@ -79,7 +79,8 @@ class Root:
 
             if not error:
                 # ensure_csrf_token_exists()  this is commented out cause I haven't yet learned what/how for CSRF
-                cherrypy.session['staffer_id'] = response['result']['public_id']
+                # cherrypy.session['staffer_id'] = str(response['result']['public_id']) # this one is for when attendee search works with Uber public ID
+                cherrypy.session['staffer_id'] = str(response['result']['badge_num']) # this one is for when attendee search is not accepting public ID, uses just badge number everywhere instead
                 cherrypy.session['badge_num'] = response['result']['badge_num']
                 
                 if is_ss_staffer(cherrypy.session['staffer_id']):
@@ -133,8 +134,8 @@ class Root:
                 session = models.new_sesh()
                 # add or update attendee record in DB
                 try:
-                    attendee = session.query(Attendee).filter_by(public_id=response['result']['public_id']).one()
-                    
+                    attendee = session.query(Attendee).filter_by(public_id=str(cherrypy.session['staffer_id'])).one()
+
                     # only update record if different
                     if not attendee.full_name == response['result']['full_name'] \
                             or not attendee.badge_num == response['result']['badge_num']:
@@ -146,7 +147,7 @@ class Root:
                     # new attendee login, creating record
                     attendee = Attendee()
                     attendee.badge_num = response['result']['badge_num']
-                    attendee.public_id = response['result']['public_id']
+                    attendee.public_id = cherrypy.session['staffer_id']
                     attendee.full_name = response['result']['full_name']
                     session.add(attendee)
                     session.commit()


### PR DESCRIPTION
Mainly the badge number thing:
As of the time of this commit Uber API is not allowing Attendee Search or Lookup with the attendee's Public ID.  The app is designed around tracking everything by their public ID, but luckily most of the system doesn't actually require that and will work with the badge number with only minor modifications.
This adds a switch in the login code (not automatic or in config at this time) to allow using badge number instead of public ID, and the necessary modifications elsewhere to allow the rest of the system to handle what it sees as an int.