### PR TITLE
Improve slack username search for pings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pdfs/
 ~$readme.rtf
 my docs/
 logs/
+Temp_Files/


### PR DESCRIPTION
Changed it so it will try to do exact lookup first, this way if for example someone has the display name Faith and someone else has a display name containing the word Faith in it somewhere it will pull the exact match without getting a multiple-match error and failing the ping.